### PR TITLE
Remove message reply errors

### DIFF
--- a/vidfetch_bot/handlers.py
+++ b/vidfetch_bot/handlers.py
@@ -25,7 +25,7 @@ async def url_handler(message: Message):
         return
     for entity in message.entities:
         log.debug(entity)
-        url = utils.extract_entity(message.text, entity)
+        url = entity.extract_from(message.text)
         log.info(f"'{url}' received from {message.from_user.username} in {message.chat.title or 'DM'}")
 
         video = Video(url)

--- a/vidfetch_bot/utils.py
+++ b/vidfetch_bot/utils.py
@@ -43,6 +43,8 @@ def generate_response(message: Message, video: Video) -> SendVideo | SetMessageR
             return message.react(reaction=[ReactionTypeEmoji(emoji="🤷")])
         case InvalidReason.DOWNLOAD_FAILED:
             return message.react(reaction=[ReactionTypeEmoji(emoji="😢")])
+        case InvalidReason.UNAUTHORIZED:
+            return message.react(reaction=[ReactionTypeEmoji(emoji="🙈")])
         case None:
             if not video.file_path:
                 raise FileNotFoundError(f"No file path for {video.title}")

--- a/vidfetch_bot/utils.py
+++ b/vidfetch_bot/utils.py
@@ -1,7 +1,6 @@
 import logging
 import re
 
-from aiogram.methods.send_message import SendMessage
 from aiogram.methods.send_video import SendVideo
 from aiogram.methods.set_message_reaction import SetMessageReaction
 from aiogram.types import FSInputFile, Message, MessageEntity, ReactionTypeEmoji
@@ -33,17 +32,17 @@ def extract_entity(text: str, entity: MessageEntity) -> str:
     return text[entity.offset : (entity.offset + entity.length)]
 
 
-def generate_response(message: Message, video: Video) -> SendVideo | SendMessage | SetMessageReaction:
+def generate_response(message: Message, video: Video) -> SendVideo | SetMessageReaction:
     log = logging.getLogger(__name__)
     match video.invalid_reason:
         case InvalidReason.FILE_TOO_BIG:
-            return message.reply(text="Video file is too big for Telegram. 😿", disable_notification=True)
+            return message.react(reaction=[ReactionTypeEmoji(emoji="🐳")])
         case InvalidReason.VIDEO_TOO_LONG:
-            return message.reply(text="Video is longer than 10 minutes. 👺", disable_notification=True)
+            return message.react(reaction=[ReactionTypeEmoji(emoji="🤨")])
         case InvalidReason.UNSUPPORTED_URL:
             return message.react(reaction=[ReactionTypeEmoji(emoji="🤷")])
         case InvalidReason.DOWNLOAD_FAILED:
-            return message.react(reaction=[ReactionTypeEmoji(emoji="🙀")])
+            return message.react(reaction=[ReactionTypeEmoji(emoji="😢")])
         case None:
             if not video.file_path:
                 raise FileNotFoundError(f"No file path for {video.title}")

--- a/vidfetch_bot/utils.py
+++ b/vidfetch_bot/utils.py
@@ -3,7 +3,7 @@ import re
 
 from aiogram.methods.send_video import SendVideo
 from aiogram.methods.set_message_reaction import SetMessageReaction
-from aiogram.types import FSInputFile, Message, MessageEntity, ReactionTypeEmoji
+from aiogram.types import FSInputFile, Message, ReactionTypeEmoji
 
 from vidfetch_bot.video import InvalidReason, Video
 
@@ -26,10 +26,6 @@ def generate_caption(video: Video) -> str:
     caption = caption.strip()
 
     return f"<tg-spoiler>{caption}</tg-spoiler>"
-
-
-def extract_entity(text: str, entity: MessageEntity) -> str:
-    return text[entity.offset : (entity.offset + entity.length)]
 
 
 def generate_response(message: Message, video: Video) -> SendVideo | SetMessageReaction:

--- a/vidfetch_bot/video.py
+++ b/vidfetch_bot/video.py
@@ -21,7 +21,7 @@ class Video:
     temp_file_dir = tempfile.gettempdir()
     common_opts = {
         "format": f"best[filesize<{max_filesize}] / best[filesize_approx<{max_filesize}] / bv*+ba / b",
-        "format_sort": ["vcodec:avc", "res:720", "acodec:aac"],
+        "format_sort": ["vcodec:avc", "res", "acodec:aac"],
         "max_filesize": max_filesize,
     }
 

--- a/vidfetch_bot/video.py
+++ b/vidfetch_bot/video.py
@@ -4,7 +4,7 @@ import tempfile
 from enum import Enum, auto
 
 from yt_dlp import YoutubeDL
-from yt_dlp.utils import DownloadError, UnsupportedError
+from yt_dlp.utils import DownloadError, ExtractorError, UnsupportedError
 
 
 class InvalidReason(Enum):
@@ -12,6 +12,7 @@ class InvalidReason(Enum):
     UNSUPPORTED_URL = auto()
     VIDEO_TOO_LONG = auto()
     FILE_TOO_BIG = auto()
+    UNAUTHORIZED = auto()
 
 
 class Video:
@@ -81,6 +82,8 @@ class Video:
                 match e.exc_info:
                     case (_, UnsupportedError(), *_):
                         return InvalidReason.UNSUPPORTED_URL
+                    case (_, ExtractorError() as ee, *_) if "--cookies" in ee.msg:
+                        return InvalidReason.UNAUTHORIZED
                     case _:
                         return InvalidReason.DOWNLOAD_FAILED
 


### PR DESCRIPTION
- Removes error message replies with reactions to keep conversations cleaner 
- Removes 720p max resolution
- Adds an unauthorized invalid reason and reaction
- Fix URL extraction when emojis (or other unicode characters) are present in the message
- Adds generate_response unit tests 